### PR TITLE
Allow weaken/strengthen operations in larger increments

### DIFF
--- a/README.lhs
+++ b/README.lhs
@@ -112,19 +112,27 @@ intervals in terms of closed intervals.
   ```haskell
     describe "bounds manipulation" $ do
 
-      let cx = 2 :: Bounds (Inclusive 1) (Exclusive 10)
+      let cx = 4 :: Bounds (Inclusive 2) (Exclusive 10)
 
       it "should allow querying the bounds" $ do
         upperBound cx `shouldBe` (Proxy :: Proxy 9)
-        lowerBound cx `shouldBe` (Proxy :: Proxy 1)
+        lowerBound cx `shouldBe` (Proxy :: Proxy 2)
 
       it "should allow weakening the bounds" $ do
         upperBound (weakenUpper cx) `shouldBe` (Proxy :: Proxy 10)
+        lowerBound (weakenLower cx) `shouldBe` (Proxy :: Proxy 1)
+
+      it "should allow weakening the bounds by more than one" $ do
+        upperBound (weakenUpper cx) `shouldBe` (Proxy :: Proxy 20)
         lowerBound (weakenLower cx) `shouldBe` (Proxy :: Proxy 0)
 
       it "should allow strengthening the bounds" $ do
         upperBound <$> strengthenUpper cx `shouldBe` Just (Proxy :: Proxy 8)
-        lowerBound <$> strengthenLower cx `shouldBe` Just (Proxy :: Proxy 2)
+        lowerBound <$> strengthenLower cx `shouldBe` Just (Proxy :: Proxy 3)
+
+      it "should allow strengthening the bounds by more than one" $ do
+        upperBound <$> strengthenUpper cx `shouldBe` Just (Proxy :: Proxy 7)
+        lowerBound <$> strengthenLower cx `shouldBe` Just (Proxy :: Proxy 4)
   ```
 
 ### Arithmetic

--- a/library/Closed/Internal.hs
+++ b/library/Closed/Internal.hs
@@ -164,16 +164,16 @@ unrepresentable x cx prefix =
 natToClosed :: (n <= x, x <= m, KnownNat x, KnownNat n, KnownNat m) => proxy x -> Closed n m
 natToClosed p = Closed $ natVal p
 
--- | Add one inhabitant at the end
-weakenUpper :: Closed n m -> Closed n (m + 1)
+-- | Add inhabitants at the end
+weakenUpper :: (n <= m, m <= k) => Closed n m -> Closed n k
 weakenUpper (Closed x) = Closed x
 
--- | Add one inhabitant at the beginning
-weakenLower :: Closed (n + 1) m -> Closed n m
+-- | Add inhabitants at the beginning
+weakenLower :: (n <= m, k <= n) => Closed n m -> Closed k m
 weakenLower (Closed x) = Closed x
 
--- | Remove one inhabitant from the end. Returns 'Nothing' if the input was removed
-strengthenUpper :: (KnownNat n, KnownNat m) => Closed n (m + 1) -> Maybe (Closed n m)
+-- | Remove inhabitants from the end. Returns 'Nothing' if the input was removed
+strengthenUpper :: (KnownNat n, KnownNat m, KnownNat k, n <= m, n <= k, k <= m) => Closed n m -> Maybe (Closed n k)
 strengthenUpper (Closed x) = result
  where
   result =
@@ -181,8 +181,8 @@ strengthenUpper (Closed x) = result
       then Just $ Closed x
       else Nothing
 
--- | Remove one inhabitant from the beginning. Returns 'Nothing' if the input was removed
-strengthenLower :: (KnownNat (n + 1), KnownNat m) => Closed n m -> Maybe (Closed (n + 1) m)
+-- | Remove inhabitants from the beginning. Returns 'Nothing' if the input was removed
+strengthenLower :: (KnownNat n, KnownNat m, KnownNat k, n <= m, n <= k, k <= m) => Closed n m -> Maybe (Closed k m)
 strengthenLower (Closed x) = result
  where
   result =

--- a/library/Closed/Internal.hs
+++ b/library/Closed/Internal.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -58,7 +59,7 @@ upperBound :: Closed n m -> Proxy m
 upperBound _ = Proxy
 
 -- | Safely create a 'Closed' value using the specified argument
-closed :: (n <= m, KnownNat n, KnownNat m) => Integer -> Maybe (Closed n m)
+closed :: forall n m. (n <= m, KnownNat n, KnownNat m) => Integer -> Maybe (Closed n m)
 closed x = result
  where
   extracted = fromJust result
@@ -68,7 +69,7 @@ closed x = result
       else Nothing
 
 -- | Create a 'Closed' value throwing an error if the argument is not in range
-unsafeClosed :: (HasCallStack, n <= m, KnownNat n, KnownNat m) => Integer -> Closed n m
+unsafeClosed :: forall n m. (HasCallStack, n <= m, KnownNat n, KnownNat m) => Integer -> Closed n m
 unsafeClosed x = result
  where
   result =
@@ -161,19 +162,19 @@ unrepresentable x cx prefix =
   " " ++ show (natVal $ upperBound cx)
 
 -- | Convert a type-level literal into a 'Closed' value
-natToClosed :: (n <= x, x <= m, KnownNat x, KnownNat n, KnownNat m) => proxy x -> Closed n m
+natToClosed :: forall n m x proxy. (n <= x, x <= m, KnownNat x, KnownNat n, KnownNat m) => proxy x -> Closed n m
 natToClosed p = Closed $ natVal p
 
 -- | Add inhabitants at the end
-weakenUpper :: (n <= m, m <= k) => Closed n m -> Closed n k
+weakenUpper :: forall k n m. (n <= m, m <= k) => Closed n m -> Closed n k
 weakenUpper (Closed x) = Closed x
 
 -- | Add inhabitants at the beginning
-weakenLower :: (n <= m, k <= n) => Closed n m -> Closed k m
+weakenLower :: forall k n m. (n <= m, k <= n) => Closed n m -> Closed k m
 weakenLower (Closed x) = Closed x
 
 -- | Remove inhabitants from the end. Returns 'Nothing' if the input was removed
-strengthenUpper :: (KnownNat n, KnownNat m, KnownNat k, n <= m, n <= k, k <= m) => Closed n m -> Maybe (Closed n k)
+strengthenUpper :: forall k n m. (KnownNat n, KnownNat m, KnownNat k, n <= m, n <= k, k <= m) => Closed n m -> Maybe (Closed n k)
 strengthenUpper (Closed x) = result
  where
   result =
@@ -182,7 +183,7 @@ strengthenUpper (Closed x) = result
       else Nothing
 
 -- | Remove inhabitants from the beginning. Returns 'Nothing' if the input was removed
-strengthenLower :: (KnownNat n, KnownNat m, KnownNat k, n <= m, n <= k, k <= m) => Closed n m -> Maybe (Closed k m)
+strengthenLower :: forall k n m. (KnownNat n, KnownNat m, KnownNat k, n <= m, n <= k, k <= m) => Closed n m -> Maybe (Closed k m)
 strengthenLower (Closed x) = result
  where
   result =


### PR DESCRIPTION
We should always be able to strengthen or weaken in any (expressible) increment. Weaken always succeeds, strengthen may fail (as before). @pbrisbin once this is merged, just change the git hash for `closed` in your branch.